### PR TITLE
Nowadays we prefer https.

### DIFF
--- a/action.php
+++ b/action.php
@@ -185,7 +185,7 @@ class action_plugin_fontface extends DokuWiki_Action_Plugin {
         if (empty($fontFileName)) {
             return false;
         }
-        return 'http://fonts.googleapis.com/css?family='.str_replace(' ', '+', $fontFileName);
+        return 'https://fonts.googleapis.com/css?family='.str_replace(' ', '+', $fontFileName);
     }
 
 }


### PR DESCRIPTION
Hello Selfthinker,

Today we prefer https over http. This change makes this plugin work over https (without messages about mixed content) and makes configuration of the Content-Security-Policy header (in nginx) easier.

A similar change is https://github.com/Azurewren/dokuwiki-plugin-googlefonts/commit/412e72bf9acd6d2d5544a9334c78fbd94b4eec0a.

With best regards,
Paul